### PR TITLE
Fixed style linking in source files

### DIFF
--- a/sources/FamilySans-Italic-MM.glyphs
+++ b/sources/FamilySans-Italic-MM.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "895";
+.appVersion = "926";
 copyright = "Copyright 2016 The Family Sans Project Authors";
 customParameters = (
 {
@@ -939,6 +939,7 @@ instanceInterpolations = {
 };
 isBold = 1;
 isItalic = 1;
+linkStyle = Regular;
 name = "Bold Italic";
 weightClass = Bold;
 },

--- a/sources/FamilySans-Roman-MM.glyphs
+++ b/sources/FamilySans-Roman-MM.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "903";
+.appVersion = "926";
 copyright = "Copyright 2016 The Family Sans Project Authors";
 customParameters = (
 {
@@ -927,6 +927,7 @@ instanceInterpolations = {
 "85AC2785-5E04-45F9-9325-840BBCF66CE9" = 0.75;
 };
 isBold = 1;
+linkStyle = Regular;
 name = Bold;
 weightClass = Bold;
 },


### PR DESCRIPTION
Fixed style linking according to 
https://github.com/googlefonts/fontbakery/issues/1096

The cluster-free method for Style linking:

![screen shot 2016-10-12 at 14 48 19](https://cloud.githubusercontent.com/assets/16634089/19329037/959d2a12-908b-11e6-98ed-532bdc98f0f3.png)

![screen shot 2016-10-12 at 14 47 54](https://cloud.githubusercontent.com/assets/16634089/19328967/35a2e354-908b-11e6-807b-e44e83bdf069.png)
